### PR TITLE
Change project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# nRF 802.15.4 sniffer
+# nRF Sniffer for 802.15.4
 
 This repository contains firmware and Wireshark extcap script that can be used with nRF52840 chip as an 802.15.4 sniffer.
 
@@ -98,7 +98,7 @@ Ensure that Python directory is included in your `PATH` system environment varia
 
 ### Start sniffing
 1. Run Wireshark.
-2. Click the gear icon next to the 'nRF 802.15.4 sniffer'.
+2. Click the gear icon next to the 'nRF Sniffer for 802.15.4'.
 3. Select the 802.15.4 channel.
 4. Select the format for out-of-band meta-data.
 5. Click 'Start'.
@@ -147,7 +147,7 @@ To capture the data for Zigbee examples in SDK, you must manually configure Wire
     - Key: `ab:cd:ef:01:23:45:67:89:00:00:00:00:00:00:00:00`, Byte Order: Normal, Label: Nordic Examples
 
 ## Out-Of-Band meta-data
-The sniffer can provide additional information. For every packet, you can display channel, RSSI and LQI. The format used for this is configurable in the Interface Options dialog (the gear icon next to the 'nRF 802.15.4 sniffer'). Depending on the Wireshark version this can be configured in two ways:
+The sniffer can provide additional information. For every packet, you can display channel, RSSI and LQI. The format used for this is configurable in the Interface Options dialog (the gear icon next to the 'nRF Sniffer for 802.15.4'). Depending on the Wireshark version this can be configured in two ways:
 
 1. For Wireshark 3.0 and later: Select "IEEE 802.15.4 TAP".
 2. For Wireshark 2.4 and 2.6: Install a custom Lua dissector and select "Custom Lua dissector".

--- a/nrf802154_sniffer/nrf802154_sniffer.lua
+++ b/nrf802154_sniffer/nrf802154_sniffer.lua
@@ -1,4 +1,4 @@
-nrf802154_sniffer_proto = Proto("nrf802154_sniffer","nRF 802.15.4 Sniffer Data")
+nrf802154_sniffer_proto = Proto("nrf802154_sniffer","nRF Sniffer for 802.15.4 Data")
 nrf802154_sniffer_proto.fields.channel = ProtoField.uint16("nrf802154_sniffer.channel", "Channel")
 nrf802154_sniffer_proto.fields.rssi = ProtoField.int16("nrf802154_sniffer.rssi", "RSSI")
 nrf802154_sniffer_proto.fields.lqi = ProtoField.uint16("nrf802154_sniffer.lqi", "LQI")
@@ -7,7 +7,7 @@ nrf802154_sniffer_proto.fields.lqi = ProtoField.uint16("nrf802154_sniffer.lqi", 
 function nrf802154_sniffer_proto.dissector(buffer, pinfo, tree)
     HEADER_LEN = 6
     if buffer:len() > HEADER_LEN then
-        local t = tree:add(nrf802154_sniffer_proto, buffer(0,HEADER_LEN), "nRF 802.15.4 Sniffer Data")
+        local t = tree:add(nrf802154_sniffer_proto, buffer(0,HEADER_LEN), "nRF Sniffer for 802.15.4 Data")
         t:add_le(nrf802154_sniffer_proto.fields.channel, buffer(0,2))
         t:add_le(nrf802154_sniffer_proto.fields.rssi, buffer(2,2))
         t:add_le(nrf802154_sniffer_proto.fields.lqi, buffer(4,2))

--- a/nrf802154_sniffer/nrf802154_sniffer.py
+++ b/nrf802154_sniffer/nrf802154_sniffer.py
@@ -184,7 +184,7 @@ class Nrf802154Sniffer(object):
         res.append("extcap {version=0.7.2}{help=https://github.com/NordicSemiconductor/nRF-Sniffer-for-802.15.4}{display=nRF Sniffer for 802.15.4}")
         for port in comports():
             if port.vid == Nrf802154Sniffer.NORDICSEMI_VID and port.pid == Nrf802154Sniffer.SNIFFER_802154_PID:
-                res.append ("interface {value=%s}{display=nRF 802.15.4 sniffer}" % (port.device,) )
+                res.append ("interface {value=%s}{display=nRF Sniffer for 802.15.4}" % (port.device,) )
 
         return "\n".join(res)
 
@@ -458,7 +458,7 @@ class Nrf802154Sniffer(object):
         """
         Helper methods to make the standalone script work in console and wireshark.
         """
-        parser = ArgumentParser(description="Extcap program for the nRF 802.15.4 sniffer")
+        parser = ArgumentParser(description="Extcap program for the nRF Sniffer for 802.15.4")
 
         parser.add_argument("--extcap-interfaces", help="Provide a list of interfaces to capture from", action="store_true")
         parser.add_argument("--extcap-interface", help="Provide the interface to capture from")

--- a/nrf802154_sniffer/nrf802154_sniffer.py
+++ b/nrf802154_sniffer/nrf802154_sniffer.py
@@ -181,10 +181,10 @@ class Nrf802154Sniffer(object):
         :return: string with wireshark-compatible information
         """
         res = []
-        res.append("extcap {version=1.0}{help=https://github.com/NordicSemiconductor/nRF-IEEE-802.15.4-radio-driver}{display=nRF 802.15.4 sniffer}")
+        res.append("extcap {version=1.0}{help=https://github.com/NordicSemiconductor/nRF-IEEE-802.15.4-radio-driver}{display=nRF Sniffer for 802.15.4}")
         for port in comports():
             if port.vid == Nrf802154Sniffer.NORDICSEMI_VID and port.pid == Nrf802154Sniffer.SNIFFER_802154_PID:
-                res.append ("interface {value=%s}{display=nRF 802.15.4 sniffer}" % (port.device,) )
+                res.append ("interface {value=%s}{display=nRF Sniffer for 802.15.4}" % (port.device,) )
 
         return "\n".join(res)
 
@@ -458,7 +458,7 @@ class Nrf802154Sniffer(object):
         """
         Helper methods to make the standalone script work in console and wireshark.
         """
-        parser = ArgumentParser(description="Extcap program for the nRF 802.15.4 sniffer")
+        parser = ArgumentParser(description="Extcap program for the nRF Sniffer for 802.15.4")
 
         parser.add_argument("--extcap-interfaces", help="Provide a list of interfaces to capture from", action="store_true")
         parser.add_argument("--extcap-interface", help="Provide the interface to capture from")

--- a/nrf802154_sniffer/nrf802154_sniffer.py
+++ b/nrf802154_sniffer/nrf802154_sniffer.py
@@ -181,10 +181,10 @@ class Nrf802154Sniffer(object):
         :return: string with wireshark-compatible information
         """
         res = []
-        res.append("extcap {version=1.0}{help=https://github.com/NordicSemiconductor/nRF-IEEE-802.15.4-radio-driver}{display=nRF Sniffer for 802.15.4}")
+        res.append("extcap {version=0.7.2}{help=https://github.com/NordicSemiconductor/nRF-Sniffer-for-802.15.4}{display=nRF Sniffer for 802.15.4}")
         for port in comports():
             if port.vid == Nrf802154Sniffer.NORDICSEMI_VID and port.pid == Nrf802154Sniffer.SNIFFER_802154_PID:
-                res.append ("interface {value=%s}{display=nRF Sniffer for 802.15.4}" % (port.device,) )
+                res.append ("interface {value=%s}{display=nRF 802.15.4 sniffer}" % (port.device,) )
 
         return "\n".join(res)
 
@@ -458,7 +458,7 @@ class Nrf802154Sniffer(object):
         """
         Helper methods to make the standalone script work in console and wireshark.
         """
-        parser = ArgumentParser(description="Extcap program for the nRF Sniffer for 802.15.4")
+        parser = ArgumentParser(description="Extcap program for the nRF 802.15.4 sniffer")
 
         parser.add_argument("--extcap-interfaces", help="Provide a list of interfaces to capture from", action="store_true")
         parser.add_argument("--extcap-interface", help="Provide the interface to capture from")


### PR DESCRIPTION
Link in nrf802154_sniffer.py is needed to be changed as well.
I think we should do it after the project is moved.